### PR TITLE
fix cover images

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -10,6 +10,8 @@ const cookieParser = require('cookie-parser');
 const multer = require('multer');
 const uploadMiddleware = multer({ dest: 'uploads/' });
 const fs = require('fs');
+const path = require('path');
+
 
 const salt = bcrypt.genSaltSync(10);
 const secret = 'asdfe45we45w345wegw345werjktjwertkj';
@@ -127,6 +129,17 @@ app.get('/post', async (req,res) => {
       .limit(20)
   );
 });
+app.get("/img/:id", async(req, res)=>{
+  
+  const imgName = req.params.id;
+  const pathIn = path.join(path.join(`${__dirname}/../uploads/${imgName}`))
+  
+  if (!fs.existsSync(pathIn)) {
+      return res.status(404).json({message: "404 image not found"});
+    }
+    
+  res.sendFile(pathIn);
+})
 
 app.get('/post/:id', async (req, res) => {
   const {id} = req.params;
@@ -134,5 +147,6 @@ app.get('/post/:id', async (req, res) => {
   res.json(postDoc);
 })
 
-app.listen(4000);
-//
+app.listen(4000, ()=>{
+  console.log('server started');
+});

--- a/client/src/Post.js
+++ b/client/src/Post.js
@@ -7,7 +7,7 @@ export default function Post({_id,title,summary,cover,content,createdAt,author})
     <div className="post">
       <div className="image">
         <Link to={`/post/${_id}`}>
-          <img src={'http://localhost:4000/'+cover} alt=""/>
+        <img src={'http://localhost:4000/img/'+cover.split('uploads\\')[1]} alt=""/>
         </Link>
       </div>
       <div className="texts">

--- a/client/src/pages/IndexPage.js
+++ b/client/src/pages/IndexPage.js
@@ -13,7 +13,7 @@ export default function IndexPage() {
   return (
     <>
       {posts.length > 0 && posts.map(post => (
-        <Post {...post} />
+        <Post {...post}  key={post._id}/>
       ))}
     </>
   );


### PR DESCRIPTION
Hi, I found a problem with the start images, they give an error and don't load. I don't know if anyone else has this problem.

![image](https://user-images.githubusercontent.com/78227006/216739296-e81029f5-2b1f-4ea3-a31d-c2487eb94cdf.png)

I tried several ways and couldn't solve it. Then I saw that a petition is made to this api route, which I visited and the image does not exist.

![image](https://user-images.githubusercontent.com/78227006/216739323-66c145c9-26e0-49f9-a3f9-ec4bc8819867.png)

Then to solve it I thought of creating a route in the API, so that when the frontend calls that route it consults the image in the API.

```js
app.get("/img/:id", async(req, res)=>{
  
  const imgName = req.params.id;
  const pathIn = path.join(path.join(`${__dirname}/../uploads/${imgName}`))
  
  if (!fs.existsSync(pathIn)) {
      return res.status(404).json({message: "404 image not found"});
    }
    
  res.sendFile(pathIn);
})
```
Basically what this does is take the file name and check if it exists in the uploads folder, and send it as a file.

In the frontend, to make few modifications, just change the url where the image is called.
```js
<img src={'http://localhost:4000/img/'+cover.split('uploads\\')[1]} alt=""/>
```

![image](https://user-images.githubusercontent.com/78227006/216739546-50e065a0-3432-4b16-be3c-177d2e01f358.png)


  
  

